### PR TITLE
catchup to main

### DIFF
--- a/robin.user.js
+++ b/robin.user.js
@@ -84,9 +84,9 @@
                     Settings.save(settings);
                 };
             }
-            $(".robin--vote-class--abandon").on("click", setVote("abandon"));
-            $(".robin--vote-class--continue").on("click", setVote("stay"));
-            $(".robin--vote-class--increase").on("click", setVote("grow"));
+            $(".robin-chat--vote.robin--vote-class--abandon").on("click", setVote("abandon"));
+            $(".robin-chat--vote.robin--vote-class--continue").on("click", setVote("stay"));
+            $(".robin-chat--vote.robin--vote-class--increase").on("click", setVote("grow"));
 
             $('.robin-chat--buttons').prepend("<div class='robin-chat--vote robin--vote-class--novote'><span class='robin--icon'></span><div class='robin-chat--vote-label'></div></div>");
             $robinVoteWidget.find('.robin-chat--vote').css('padding', '5px');

--- a/robin.user.js
+++ b/robin.user.js
@@ -176,36 +176,6 @@
 
     var list = {};
     $(".text-counter-input").val(settings.filterChannel? settings.channel+" " :"")
-    $(".text-counter-input").keydown(function(e) {
-        console.log('keyup called');
-        var text = $(".text-counter-input").val();
-        var code = e.keyCode || e.which;
-        if (code == '9') {
-            var nameParts = text.split(" ");
-            var namePart = nameParts[nameParts.length-1].toLowerCase();
-            var allNames = list.map(function(a){return a.name;});
-            console.log(allNames);
-            for(var i = 0; i < allNames.length; i++) {
-                if(allNames[i].toLowerCase().indexOf(namePart) == 0) {
-                    var goodText = "";
-                    for(var j = 0; j < nameParts.length-1; j++) {
-                        goodText = goodText+nameParts[j]+" ";
-                    }
-                    goodText = goodText+allNames[i];
-                    $(".text-counter-input").val(goodText);
-                    break;
-                }
-            }
-        } else if(code == '13') {
-            if(settings.filterChannel &&
-                String(settings.channel).length > 0) {
-
-                    setTimeout(function() {
-                        $(".text-counter-input").val(settings.channel+" ");
-                    }, 10);
-                }
-        }
-    });
 
     function update() {
         switch(settings.vote) {

--- a/robin.user.js
+++ b/robin.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Robin Grow
 // @namespace    http://tampermonkey.net/
-// @version      1.820
+// @version      1.830
 // @description  Try to take over the world!
 // @author       /u/mvartan
 // @include      https://www.reddit.com/robin*

--- a/robin.user.js
+++ b/robin.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Robin Grow
 // @namespace    http://tampermonkey.net/
-// @version      1.830
+// @version      1.840
 // @description  Try to take over the world!
 // @author       /u/mvartan
 // @include      https://www.reddit.com/robin*
@@ -176,8 +176,13 @@
 
     var list = {};
     $(".text-counter-input").val(settings.filterChannel? settings.channel+" " :"")
+    $(".text-counter-input").keyup(function(e) {
+        if(settings.filterChannel && $(".text-counter-input").val().indexOf(settings.channel) != 0) {
+            $(".text-counter-input").val(settings.channel+" "+$(".text-counter-input").val())
+        }
+    });
+
     $(".text-counter-input").keydown(function(e) {
-        console.log('keyup called');
         var text = $(".text-counter-input").val();
         var code = e.keyCode || e.which;
         if(code == 13) {

--- a/robin.user.js
+++ b/robin.user.js
@@ -176,6 +176,20 @@
 
     var list = {};
     $(".text-counter-input").val(settings.filterChannel? settings.channel+" " :"")
+    $(".text-counter-input").keydown(function(e) {
+        console.log('keyup called');
+        var text = $(".text-counter-input").val();
+        var code = e.keyCode || e.which;
+        if(code == 13) {
+            if(settings.filterChannel &&
+                String(settings.channel).length > 0) {
+
+                    setTimeout(function() {
+                        $(".text-counter-input").val(settings.channel+" ");
+                    }, 10);
+                }
+        }
+    });
 
     function update() {
         switch(settings.vote) {

--- a/robin.user.js
+++ b/robin.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Robin Grow
 // @namespace    http://tampermonkey.net/
-// @version      1.705
+// @version      1.8
 // @description  Try to take over the world!
 // @author       /u/mvartan
 // @include      https://www.reddit.com/robin*

--- a/robin.user.js
+++ b/robin.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Robin Grow
 // @namespace    http://tampermonkey.net/
-// @version      1.810
+// @version      1.820
 // @description  Try to take over the world!
 // @author       /u/mvartan
 // @include      https://www.reddit.com/robin*
@@ -175,6 +175,7 @@
     var urlRegex = new RegExp(/(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))\.?)(?::\d{2,5})?(?:[/?#]\S*)?/ig);
 
     var list = {};
+    $(".text-counter-input").val(settings.filterChannel? settings.channel+" " :"")
     $(".text-counter-input").keydown(function(e) {
         console.log('keyup called');
         var text = $(".text-counter-input").val();
@@ -390,7 +391,6 @@
     $("#robinChatMessageList").each(function() {
         myObserver.observe(this, { childList: true });
     });
-
     function mutationHandler(mutationRecords) {
         mutationRecords.forEach(function(mutation) {
             var jq = $(mutation.addedNodes);
@@ -409,10 +409,24 @@
                         String(settings.channel).length > 0 &&
                         !hasChannel(messageText, settings.channel));
 
+
+                if(nextIsRepeat && jq.hasClass('robin--user-class--system')) {
+                }
+                var nextIsRepeat = jq.hasClass('robin--user-class--system') && messageText.indexOf("try again") >= 0;
+                if(nextIsRepeat) {
+                    $(".text-counter-input").val(jq.next().find(".robin-message--message").text());
+                }
+
+                remove_message = remove_message && !jq.hasClass("robin--user-class--system");
                 if (remove_message) {
                     $message = null;
                     $(jq[0]).remove();
                 } else {
+                    if(settings.filterChannel) {
+                        if(messageText.indexOf(settings.channel) == 0) {
+                            $message.text(messageText.substring(settings.channel.length).trim());
+                        }
+                    }
                     if (messageText.toLowerCase().indexOf(currentUsersName.toLowerCase()) !== -1) {
                         $message.parent().css("background","#FFA27F").css("color","white");
                         notifAudio.play();

--- a/robin.user.js
+++ b/robin.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Robin Grow
 // @namespace    http://tampermonkey.net/
-// @version      1.801
+// @version      1.810
 // @description  Try to take over the world!
 // @author       /u/mvartan
 // @include      https://www.reddit.com/robin*
@@ -194,6 +194,14 @@
                     break;
                 }
             }
+        } else if(code == '13') {
+            if(settings.filterChannel &&
+                String(settings.channel).length > 0) {
+
+                    setTimeout(function() {
+                        $(".text-counter-input").val(settings.channel+" ");
+                    }, 10);
+                }
         }
     });
 

--- a/robin.user.js
+++ b/robin.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Robin Grow
 // @namespace    http://tampermonkey.net/
-// @version      1.8
+// @version      1.801
 // @description  Try to take over the world!
 // @author       /u/mvartan
 // @include      https://www.reddit.com/robin*
@@ -286,8 +286,8 @@
         if (settings.findAndHideSpam) {
             var $messages = $(".robin--user-class--user");
 
-            if ($messages.length > 250) {
-                $messages.slice(0, $messages.length - 250).remove();
+            if ($messages.length > 1000) {
+                $messages.slice(0, $messages.length - 1000).remove();
             }
 
             // skips over ones that have been hidden during this run of the loop


### PR DESCRIPTION
* Re-color user name list occasionally

When a user goes/comes back from idle they lose their color because their style attribute is lost when updated. My change sets the coloring on a timer (at an interval to rarely intersect with the `update()` one) and modifies the selector to only attempt to style usernames that are not already styled.

* Fix hiding time left display when 'ending soon'

Forgot to check is we're ending soon before hiding the time remaining display box.

* Switch user list name re-coloring to use MutationObserver

Changed from the timed intervals to an observer.

* Styling support for RES Night Mode

Styling to work with RES's Night Mode, including some styling for things this script specifically does.

Only gets inserted if the user has RES installed, and only does any styling if they have Night Mode enabled or enable it. Will disable if they toggle Night Mode off, as all styles are scoped to Night Mode specifically.

Inline via JS isn't my preferred way to do styling, but I think this is the best way to get it to the most users quickly and have it "just work" the easiest, especially while Robin is even still a thing.

* bump version

* Fix spelling mistake

* added ability to unmute users from settings

* custom spam filters